### PR TITLE
Add ValidatorWrapper and convenience functions

### DIFF
--- a/Sources/Forms/Validation+convenience.swift
+++ b/Sources/Forms/Validation+convenience.swift
@@ -1,0 +1,15 @@
+import Validation
+
+extension Validator {
+    public func transformingErrors(
+        to error: Error
+    ) -> ValidatorWrapper<Input> {
+        return ValidatorWrapper(validator: self, error: error)
+    }
+
+    public func allowingNil(
+        _ isOptional: Bool = true
+    ) -> OptionalValidator<Input> {
+        return OptionalValidator(isOptional: isOptional, validator: self)
+    }
+}

--- a/Sources/Forms/ValidatorWrapper.swift
+++ b/Sources/Forms/ValidatorWrapper.swift
@@ -1,0 +1,25 @@
+import Validation
+
+/// Simple wrapper that catches any error on validate and throws provided error.
+public struct ValidatorWrapper<Input: Validatable> {
+    fileprivate let error: Error
+    fileprivate let wrappedValidate: (Input) throws -> Void
+
+    public init<V: Validator>(
+        validator: V,
+        error: Error
+    ) where V.Input == Input {
+        self.wrappedValidate = validator.validate
+        self.error = error
+    }
+}
+
+extension ValidatorWrapper: Validator {
+    public func validate(_ input: Input) throws {
+        do {
+            try wrappedValidate(input)
+        } catch {
+            throw self.error
+        }
+    }
+}


### PR DESCRIPTION
Allows for example:

```swift
StrongPassword()
    .transformingErrors(to: MyAppErrors.passwordTooWeak)
    .allowingNil(false)
```

which allows uses an existing (e.g. StrongPassword) validator but transforms the errors into something more suited to your needs and also adds a requirement that the value be non-nil.